### PR TITLE
Update typedoc.yml to also trigger on prereleases

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -3,8 +3,7 @@ name: TypeDoc
 
 on:
   # Runs on new releases
-  release:
-    types: [published]
+  release: {}
   push:
     branches: [main]
 


### PR DESCRIPTION
### What kind of pull request did you make?

- [x] Other - Build update

### Changelog

Build of typed was not firing when releases were marked as pre-releases. Since the latest version is still a beta, that means that the docs were never attached to the release.